### PR TITLE
custom ps field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ installation using setup.py, user install in `~/.local/bin`:
 ## Usage
 ```
 # pgtree -h
-    usage: pgtree.py [-ICya] [-c|-k|-K] [-p <pid1>,...|<pgrep args>]
+    usage: pgtree.py [-ICya] [-O <psfield>] [-c|-k|-K] [-p <pid1>,...|<pgrep args>]
 
     -I : use -o uid instead of -o user for ps command
          (if uid/user mapping is broken ps command can be stuck)
@@ -54,6 +54,8 @@ installation using setup.py, user install in `~/.local/bin`:
     -y : do not ask for confirmation to kill
     -C : no color (default colored output on tty)
     -a : use ascii characters
+    -O <psfield> : display <psfield> instead of 'stime' in output
+                   <psfield> must be valid with ps -o <psfield> command
 
     by default display full process hierarchy (parents + children of selected processes)
 

--- a/pgtree/_version.py
+++ b/pgtree/_version.py
@@ -7,5 +7,5 @@ Provides pgtree version information.
 
 from incremental import Version
 
-__version__ = Version('pgtree', 1, 0, 12)
+__version__ = Version("pgtree", 1, 0, 13)
 __all__ = ["__version__"]

--- a/pgtree/pgtree.py
+++ b/pgtree/pgtree.py
@@ -110,7 +110,7 @@ class Proctree:
         """parse unix ps command"""
         osname = platform.system()
         stime = 'stime'
-        if osname == 'AIX':
+        if osname in ['AIX', 'Darwin']:
             stime = 'start'
         if psfield:
             stime = psfield

--- a/pgtree/pgtree.py
+++ b/pgtree/pgtree.py
@@ -124,7 +124,7 @@ class Proctree:
         # ps field header does not exceed 132 columns (bug?)
         cmd = ['ps', '-e', '-o', 'pid='+20*'-', '-o', 'ppid='+20*'-', '-o', user+'='+30*'-',
                '-o', stime+'='+50*'-', '-o', comm+'='+130*'-', '-o', 'args']
-        print(' '.join(cmd))
+        # print(' '.join(cmd))
         out = runcmd(cmd)
         ps_out = out.split('\n')
         for line in ps_out[1:]:

--- a/pgtree/pgtree.py
+++ b/pgtree/pgtree.py
@@ -93,6 +93,7 @@ class Proctree:
     Proctree([ 'pid1', 'pid2' ])
     """
 
+    # pylint: disable=R0913
     def __init__(self, pids=('1'), use_uid=False, use_ascii=False, use_color=False, psfield=None):
         """constructor"""
         self.pids = pids         # pids to display hierarchy
@@ -310,7 +311,7 @@ def main(argv):
         after = ''
     ptree = Proctree(pids=found, use_uid='-I' in options,
                      use_ascii='-a' in options,
-                     use_color='-C' not in options,psfield=psfield)
+                     use_color='-C' not in options, psfield=psfield)
     ptree.print_tree(child_only='-c' in options, sig=sig,
                      confirmed='-y' in options)
     sys.stdout.write(after)

--- a/tests/test_pgtree.py
+++ b/tests/test_pgtree.py
@@ -120,5 +120,10 @@ class ProctreeTest(unittest.TestCase):
         print('main6 ========')
         pgtree.main(['-a'])
 
+    def test_main7(self):
+        """test"""
+        print('main6 ========')
+        pgtree.main(['-O', '%cpu', 'bash'])
+
 if __name__ == "__main__":
     unittest.main(failfast=True)

--- a/tests/test_pgtree.py
+++ b/tests/test_pgtree.py
@@ -14,12 +14,12 @@ class ProctreeTest(unittest.TestCase):
     def test_tree1(self, mock_runcmd, mock_kill):
         """test"""
         print("tree: =======")
-        ps_out = """-------------------- -------------------- -------------------- ------------------------------ ---------------------------------------------------------------------------------------------------------------------------------- ---
-                   1                    0                Aug12 root                           init                                                                                                                               /init
-                  10                    1                Aug12 joknarf                        bash                                                                                                                               -bash
-                  20                   10                10:10 joknarf                        sleep                                                                                                                              /bin/sleep 60
-                  30                   10                10:10 joknarf                        top                                                                                                                                /bin/top
-                  40                    1                11:01 root                           bash                                                                                                                               -bash"""
+        ps_out = """-------------------- -------------------- ------------------------------ -------------------------------------------------- ---------------------------------------------------------------------------------------------------------------------------------- ---
+                   1                    0 root                                                                        Aug12 init                                                                                                                               /init
+                  10                    1 joknarf                                                                     Aug12 bash                                                                                                                               -bash
+                  20                   10 joknarf                                                                     10:10 sleep                                                                                                                              /bin/sleep 60
+                  30                   10 joknarf                                                                     10:10 top                                                                                                                                /bin/top
+                  40                    1 root                                                                        11:01 bash                                                                                                                               -bash"""
         mock_runcmd.return_value = ps_out
         mock_kill.return_value = True
         ptree = pgtree.Proctree(pids=['10'])
@@ -75,6 +75,7 @@ class ProctreeTest(unittest.TestCase):
         print(ptree.pids_tree)
         ptree.print_tree(True)
         self.assertEqual(ptree.children, children)
+        self.maxDiff =  None
         self.assertEqual(ptree.ps_info, ps_info)
         self.assertEqual(ptree.pids_tree, pids_tree)
         self.assertEqual(ptree.selected_pids, selected_pids)


### PR DESCRIPTION
add `-O <psfield>` option
display custom ps field instead of `stime`.
```
# pgtree -O size -p $$
  1     (root) [systemd] 19524 /sbin/init
  └─1929  (parallels) [systemd] 1908 /lib/systemd/systemd --user
    └─2712  (parallels) [gnome-terminal-] 63448 /usr/libexec/gnome-terminal-server
►     └─27216 (parallels) [bash] 2904 bash
```
